### PR TITLE
PhpStorm plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+script:
+- mkdir plugin/Laravel3/
+- cp ide_helper.php plugin/Laravel3/
+- cd plugin/
+- zip -r laravel3-code-completion-helper-$TRAVIS_TAG.jar *
+deploy:
+  provider: releases
+  api_key:
+    secure: UPhnEz6CE/QkhWkLFJlmv2qheDN0N2UzNjoMHIndp8TtDzl8PjIbRhPCstMbHiKiZsvCN1JLE6Je+l4yvDhFNUcmpKFU6PWvENn+NULssrxTgPQ369ZS9MC+oAsT0lG0iX33nzExtshtGF81f6v8zkO65qclrn/nQJSH0PuypIAwRlQLghjlAH2+ThebxNBBYnMmv7ZYj6AQjC0+3AAANB7dy8RgCHy3jfDiagK4hBwzbICE79cNNx/AMQR1VcvD7Dz/r26kvjCH3LwN1OdUxWe9crt/klk8ATFOjULgnLZG3jSzbzMWAFYzOW5QYoDCMjZHfQ4v0DzSwxmMIV+2VQ3mVPEiq5Fw+YePIl7OQuYMgJQkgZGoKEGLbEeEYlKUleBxabq3G0RFs08I+H+60nwinriKQNfIJffMHUuIFcqOiSj0WgRrSNg3yNzK0wmh8piaXvuJIVDcfNb8vZA0vf2vi7NipgvKxL8ZHDdNpcS3YPNhloTebfA1WG+tML6ENnXjtqAvZjJP48jOlniXCld6t6jTuzFJ78KbNFVM3KBo9zOzlQivhnMnInqMpw5o3bdNfJr13U18fH/1vUZZcmxNCjYqnwSZDBgMfnUxSTzmEPlwFTvhY72OB/A/uKYs2QiZqhXSo5ATbR+1y0tw5c/X9LjQqJAuviHjiqyobWU=
+  file: laravel3-code-completion-helper-$TRAVIS_TAG.jar
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Laravel 3 IDE Helper
 ===============
 
+[![Build Status](https://travis-ci.org/artspb/laravel-3-ide-helper.svg?branch=master)](https://travis-ci.org/artspb/laravel-3-ide-helper)
+
 Provides Laravel 3 auto-completion for Jetbrains PHPStorm
 
 The purpose if this repository is to collaborate on keeping the helper file up to date, so please feel free to submit pull requests :)

--- a/plugin/META-INF/plugin.xml
+++ b/plugin/META-INF/plugin.xml
@@ -1,0 +1,27 @@
+<idea-plugin version="2">
+    <id>me.artpsb.idea.plugin.laravel.three.code.completion.helper</id>
+    <name>Laravel 3 Code Completion Helper</name>
+    <version>1.0</version>
+    <vendor email="contact@artspb.me" url="https://artspb.me">Artem Khvastunov</vendor>
+
+    <description><![CDATA[
+    Provides code completion support for Laravel 3.
+  ]]></description>
+
+    <change-notes><![CDATA[
+    <h3>1.0</h3>
+    <ul>
+      <li>Initial support.</li>
+    </ul>
+  ]]>
+    </change-notes>
+
+    <idea-version since-build="163.3984"/>
+
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.jetbrains.php</depends>
+
+    <extensions defaultExtensionNs="com.jetbrains.php">
+        <libraryRoot id="Laravel3" path="/Laravel3/" runtime="false"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
The pull request provides ability to build a PhpStorm plugin on top of an already existing helper. The build process is fully automated and done by Travis CI. [Here](https://github.com/artspb/laravel-3-ide-helper/releases) you can see how does it look like.

Note: the plugin works only in PhpStorm 2016.3 EAP which will be delivered later this week.

To configure your repository you need to:
0. Merge the pull request.
1. Create a build job on [Travis CI](https://travis-ci.org/).
2. [Generate](https://docs.travis-ci.com/user/deployment/releases/) new `api_key` and replace old one in `.travis.yml`. To do this I prefer to use a console client (`travis setup releases`) because it generates the key and encrypts it in one simple step.
3. Update the button in `README.md`.

After that the build job will upload plugins to each new tag.

Optionally you can update `<id>` and `<vendor>` tags in a `plugin.xml` file and upload a plugin to the [JetBrains plugin repository](https://plugins.jetbrains.com/). I'd be really grateful if you do this.
